### PR TITLE
Create Page To Show User Repositories

### DIFF
--- a/lib/api_service/github_api.dart
+++ b/lib/api_service/github_api.dart
@@ -1,0 +1,134 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:github_var_updater/utils/app_notifier.dart';
+import 'package:http/http.dart' as http;
+import 'package:github_var_updater/utils/keystore.dart';
+
+/// Encapsulates required fields about github user
+class GithubUser {
+  final String username;
+  final String accessToken;
+
+  const GithubUser({required this.username, required this.accessToken});
+}
+
+enum RepositoryRelationType {
+  userOwned,        /// Owned by the user (Highest Priority)
+  collaboratorOnly, /// User is a collaborator (but not in an org)
+  organizationOwned /// Organization-Owned Repositories (Lowest Priority)
+}
+
+/// Encapsulates required fields about github repository
+class GithubRepository {
+  final String name;
+  final String fullName;
+  final bool isPrivate;
+  final RepositoryRelationType relationType;
+
+  const GithubRepository({
+    required this.name,
+    required this.fullName,
+    required this.isPrivate,
+    required this.relationType,
+  });
+}
+
+/// This class is used to get user data from github using api requests
+class GithubApi {
+  static final String _baseUrl = 'https://api.github.com';
+  static GithubUser? _user;
+
+  static GithubUser? get currentUser => _user;
+
+  /// Sets given [user] the current user and any 
+  static void setCurrentUser(GithubUser user) {
+    _user = user;
+    Keystore.savePair(key: 'github_username', value: user.username);
+    Keystore.savePair(key: 'github_access_token', value: user.accessToken);
+  }
+
+  static Future<void> loadPreviousUser() async {
+    if (await Keystore.contains(key: 'github_username') && await Keystore.contains(key: 'github_access_token')) {
+      _user = GithubUser(
+        username: await Keystore.getValueForKey(key: 'github_username') as String,
+        accessToken: await Keystore.getValueForKey(key: 'github_access_token') as String
+      );
+    }
+  }
+
+  /// Returns all repositories of current user.
+  /// 
+  /// Returns [null] if any error occurs.
+  static Future<List<GithubRepository>?> getUserRepos({
+    int requiredPage = 1,
+    int perPage = 30
+  }) async {
+    if (_user == null) {
+      AppNotifier.showErrorDialog(
+        errorMessage: "Cannot get repositories for current user! Please provide required information on github account section!"
+      );
+      return null;
+    }
+
+    late final http.Response response;
+
+    try {
+      final uri = Uri.parse('$_baseUrl/user/repos?per_page=$perPage&page=$requiredPage');
+      response = await http.get(
+        uri,
+        headers: {
+          'Authorization' : 'Bearer ${_user?.accessToken}',
+          'Accept' : 'application/vnd.github+json'
+        }
+      );
+    } on SocketException {
+      AppNotifier.notifyUserAboutInfo(info: 'Please check your internet!');
+      return null;
+    } catch (e) {
+      AppNotifier.showErrorDialog(errorMessage: 'Unexpected error occured: ${e.toString()}');
+      return null;
+    }
+
+    if (response.statusCode == 200) {
+      List<dynamic> repos = jsonDecode(response.body);
+
+      List<GithubRepository> repositories = repos.map((repoAsJson) {
+        RepositoryRelationType relationType;
+        String ownerLogin = repoAsJson['owner']['login'];
+        String ownerType = repoAsJson['owner']['type'];
+
+        if (ownerLogin == _user!.username) {
+          relationType = RepositoryRelationType.userOwned;
+        } else if (ownerType == 'Organization') {
+          relationType = RepositoryRelationType.organizationOwned;
+        } else {
+          relationType = RepositoryRelationType.collaboratorOnly;
+        }
+
+        return GithubRepository(
+          name: repoAsJson['name'],
+          fullName: repoAsJson['full_name'],
+          isPrivate: repoAsJson['private'],
+          relationType: relationType,
+        );
+      }).toList();
+
+      repositories.sort((a, b) {
+        return a.relationType.index.compareTo(b.relationType.index);
+      });
+  
+      return repositories;
+    } else if (response.statusCode == 401) {
+      AppNotifier.notifyUserAboutError(errorMessage: 'Please provide valid credentials! Current ones are invalid!');
+    } else if (response.statusCode == 403) {
+      AppNotifier.notifyUserAboutError(
+        errorMessage: "Either github api rate limit exceeded or your token doesn't have required permissions"
+      );
+    } else {
+      AppNotifier.showErrorDialog(
+        errorMessage: 'Unknown error occured while trying to get repositories.\nResponse Status Code: ${response.statusCode}'
+      );
+    }
+    return null;
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:github_var_updater/utils/keystore.dart';
+import 'package:github_var_updater/utils/app_notifier.dart';
 
 void main() {
   runApp(const App());
@@ -17,7 +18,7 @@ class App extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.green),
         useMaterial3: true,
       ),
-      home: HomePage(),
+      home: HomePage(key: AppNotifier.homePageKey),
     );
   }
 }
@@ -34,23 +35,18 @@ class HomePageState extends State<HomePage> {
   final TextEditingController controller = TextEditingController();
 
   Future<void> _saveApiToken() async {
-    if (controller.text.isEmpty) return;
-    try {
-      await Keystore.savePair(key: 'github_api_token', value: controller.text);
-      setState(() => token = controller.text);
-    } catch (e) {
-      print('An error occured: ${e.toString()}');
+    if (controller.text.isEmpty) {
+      AppNotifier.notifyUserAboutError(errorMessage: "Github Api Token (AKA access token) can't be empty");
+      return;
     }
+    await Keystore.savePair(key: 'github_api_token', value: controller.text);
+    setState(() => token = controller.text);
   }
 
   Future<void> _fetchApiToken() async {
-  try {
-      String? githubToken = await Keystore.getValueForKey(key: 'github_api_token');
-      if (githubToken != null) {
-        setState(() => token = githubToken);
-      }
-    } catch (e) {
-      print('An error occured: ${e.toString()}');
+    String? githubToken = await Keystore.getValueForKey(key: 'github_api_token');
+    if (githubToken != null) {
+      setState(() => token = githubToken);
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,7 +17,7 @@ class MyApp extends StatelessWidget {
       title: 'Github Var Updater',
       theme: ThemeData.light(),
       darkTheme: ThemeData.dark(),
-      themeMode: ThemeMode.dark,  // Follow system settings
+      themeMode: ThemeMode.system,  // Follow system settings
       home: MainScreen(key: AppNotifier.homePageKey),
     );
   }

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:github_var_updater/sections/github_account_section.dart';
+import 'package:github_var_updater/sections/repository_section.dart';
+
+class MainScreen extends StatefulWidget {
+  const MainScreen({super.key});
+
+  @override
+  State<MainScreen> createState() => MainScreenState();
+}
+
+class MainScreenState extends State<MainScreen> {
+
+  late PageController _pageController;
+  int _selectedIndex = 0;
+
+  void _onPageChanged(int index) {
+    setState(() => _selectedIndex = index);
+  }
+
+  void _onItemTapped(int index) {
+    _pageController.animateToPage(
+      index, 
+      duration: Duration(milliseconds: 500),
+      curve: Curves.ease
+    );  
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _pageController = PageController();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        centerTitle: true,
+        title: const Text(
+          'Github Var Updater',
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.vertical(
+            bottom: Radius.circular(8.0),
+          ),
+        ),
+      ),
+      body: PageView(
+        controller: _pageController,
+        onPageChanged: _onPageChanged,
+        children: [
+          const GithubAccountSection(),
+          const RepositorySection(),
+        ],
+      ),
+      bottomNavigationBar: Container(
+        decoration: BoxDecoration(
+          borderRadius: const BorderRadius.only(
+            topLeft: Radius.circular(20),
+            topRight: Radius.circular(20),
+          ),
+          boxShadow: [
+            BoxShadow(color: Theme.of(context).primaryColorDark, spreadRadius: 0, blurRadius: 10),
+          ]
+        ),
+        child: ClipRRect(
+          borderRadius: const BorderRadius.only(
+            topLeft: Radius.circular(20),
+            topRight: Radius.circular(20),
+          ),
+          child: BottomNavigationBar(
+            items: [
+              const BottomNavigationBarItem(
+                icon: Icon(Icons.person, size: 24),
+                label: 'Github Account',
+                activeIcon: Icon(Icons.person, size: 28)
+              ),
+              const BottomNavigationBarItem(
+                icon: Icon(Icons.list_alt, size: 24),
+                label: 'Repositories',
+                activeIcon: Icon(Icons.list_alt, size: 28)
+              )
+            ],
+            backgroundColor: Theme.of(context).dialogBackgroundColor,
+            currentIndex: _selectedIndex,
+            selectedItemColor: Colors.blue,
+            onTap: _onItemTapped,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/sections/github_account_section.dart
+++ b/lib/sections/github_account_section.dart
@@ -1,0 +1,255 @@
+import 'package:flutter/material.dart';
+import 'package:github_var_updater/api_service/github_api.dart';
+import 'package:github_var_updater/utils/app_notifier.dart';
+import 'package:github_var_updater/widgets/input_widget.dart';
+import 'package:github_var_updater/widgets/styled_text_button.dart';
+
+class GithubAccountSection extends StatefulWidget {
+  const GithubAccountSection({super.key});
+
+  @override
+  State<GithubAccountSection> createState() => _GithubAccountSectionState();
+}
+
+class _GithubAccountSectionState extends State<GithubAccountSection> {
+  final TextEditingController usernameController = TextEditingController();
+  final TextEditingController tokenController = TextEditingController();
+
+  bool areCredentialsRequired = true;
+
+  void _setCurrentUser() {
+    if (usernameController.text.isEmpty || tokenController.text.isEmpty) {
+      AppNotifier.notifyUserAboutError(errorMessage: 'Both fields are required! Please provide your username and github api token.');
+      return;
+    }
+
+    GithubApi.setCurrentUser(
+      GithubUser(
+        username: usernameController.text,
+        accessToken: tokenController.text,
+      )
+    );
+
+    // This will cause a rebuild
+    _toggleCredentialsRequired();
+  }
+
+  void _toggleCredentialsRequired() {
+    setState(() => areCredentialsRequired = !areCredentialsRequired);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    areCredentialsRequired = GithubApi.currentUser == null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.all(8.0),
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (areCredentialsRequired) ...[
+              InputWidget(
+                controller: usernameController,
+                prefixText: 'Username',
+                labelText: 'Github Username',
+                hintText: 'Enter your github username',
+              ),
+              const SizedBox(height: 40),
+              InputWidget(
+                controller: tokenController,
+                prefixText: 'Api Token',
+                labelText: 'Github Api Token',
+                hintText: 'Paste your github api token here',
+              ),
+              const SizedBox(height: 40),
+              StyledTextButton(
+                onPressed: _setCurrentUser,
+                text: const Text(
+                  'Continue',
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ] else ...[
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const Text(
+                        'Current User Details',
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 25
+                        ),
+                      ),
+                      const Divider(
+                        thickness: 1,
+                      ),
+                      const SizedBox(height: 30),
+                      InputWidget(
+                        initialValue: GithubApi.currentUser?.username ?? 'Unexpectedly Null',
+                        prefixText: 'Username',
+                        readOnly: true,
+                      ),
+                      const SizedBox(height: 30),
+                      InputWidget(
+                        initialValue: GithubApi.currentUser?.accessToken ?? 'Unexpectedly Null',
+                        prefixText: 'Api Token',
+                        readOnly: true,
+                      ),
+                      const SizedBox(height: 30),
+                      StyledTextButton(
+                        onPressed: _toggleCredentialsRequired,
+                        text: const Text(
+                          'Change User',
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              
+
+              /*Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Row (
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text(
+                            'Your Github Token',
+                            style: TextStyle(
+                              fontWeight: FontWeight.bold,
+                              fontSize: 25,
+                            ),
+                          ),
+                          IconButton(
+                            icon: Icon(Icons.copy),
+                            tooltip: 'Copy Token',
+                            onPressed: () =>
+                              Clipboard.setData(ClipboardData(text: GithubApi.currentUser?.accessToken ?? '')),
+                          ),
+                        ],
+                      ),
+                      const Divider(),
+                      Text(
+                        "${GithubApi.currentUser?.accessToken}",
+                        style: TextStyle(
+                          fontSize: 18,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),*/
+            ]
+          ],
+        ),
+      ),
+    );
+
+    /*return Padding(
+      padding: EdgeInsets.all(8.0),
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            if (token == null) ...[
+              TextField(
+                controller: controller,
+                decoration: InputDecoration(
+                  icon: Icon(Icons.person),
+                  labelText: 'Github Access Token',
+                  hintText: 'Paste github access token here',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: _saveApiToken,
+                child: Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 24, vertical: 14),
+                  child: Text('Continue'),
+                ),
+              ),
+            ] else ...[
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Row (
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text(
+                            'Your Github Token',
+                            style: TextStyle(
+                              fontWeight: FontWeight.bold,
+                              fontSize: 25,
+                            ),
+                          ),
+                          IconButton(
+                            icon: Icon(Icons.copy),
+                            tooltip: 'Copy Token',
+                            onPressed: () =>
+                              Clipboard.setData(ClipboardData(text: token ?? '')),
+                          ),
+                        ],
+                      ),
+                      const Divider(),
+                      Text(
+                        '$token',
+                        style: TextStyle(
+                          fontSize: 18,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton.icon(
+                onPressed: () => setState(() => token = null),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.red,
+                  foregroundColor: Colors.white,
+                  iconColor: Colors.white,
+                  iconSize: 35,
+                ),
+                icon: Icon(Icons.change_circle),
+                label: Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 24, vertical: 14),
+                  child: Text(
+                    'Change Token',
+                    style: TextStyle(
+                      backgroundColor: Colors.red,
+                      color: Colors.white,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );*/
+  }
+}

--- a/lib/sections/repository_section.dart
+++ b/lib/sections/repository_section.dart
@@ -146,15 +146,20 @@ class _RepositorySectionState extends State<RepositorySection> {
               ),
             ] else ...[
               for (int i = 0; i < repositories!.length; i++) ...[
-                ListTile(
-                  leading: const Icon(Icons.folder_special, color: Colors.blueAccent),
-                  title: Text(
-                    repositories![i].fullName,
-                    style: const TextStyle(
-                      fontWeight: FontWeight.bold,
+                InkWell(
+                  onTap: () {},
+                  borderRadius: BorderRadius.circular(12),
+                  child: ListTile(
+                    leading: const Icon(Icons.folder_special, color: Colors.blueAccent),
+                    contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                    title: Text(
+                      repositories![i].fullName,
+                      style: const TextStyle(
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
+                    subtitle: Text('${repositories![i].isPrivate? "Private" : "Public"} Repository'),
                   ),
-                  subtitle: Text('${repositories![i].isPrivate? "Private" : "Public"} Repository'),
                 ),
                 if (i != repositories!.length-1) ...[
                   const Divider(thickness: 1)

--- a/lib/sections/repository_section.dart
+++ b/lib/sections/repository_section.dart
@@ -1,0 +1,198 @@
+import 'package:flutter/material.dart';
+import 'package:github_var_updater/api_service/github_api.dart';
+import 'package:github_var_updater/widgets/styled_text_button.dart';
+
+class RepositorySection extends StatefulWidget {
+  const RepositorySection({super.key});
+
+  @override
+  State<RepositorySection> createState() => _RepositorySectionState();
+}
+
+class _RepositorySectionState extends State<RepositorySection> {
+
+  List<GithubRepository>? repositories;
+  bool repoBeingFetched = false;
+  int currentPage=1;
+  static const repoPerPage = 10;
+
+  Future<void> _getRepositories() async {
+    // Will start displaying circular progress indicator
+    setState(() => repoBeingFetched = true);
+    repositories = await GithubApi.getUserRepos(
+      requiredPage: currentPage,
+      perPage: repoPerPage,
+    );
+    // Will stop displaying circual progress indicator
+    setState(() => repoBeingFetched = false);
+  }
+
+  void nextPage() {
+    setState(() {
+      currentPage++;
+      // So that progress indicator can be shown
+      repositories = null;
+    });
+    // Set state will be called in this repo
+    _getRepositories();
+  }
+
+  void previousPage() {
+    setState(() {
+      currentPage--;
+      // So that progress indicator can be shown
+      repositories = null;
+    });
+    _getRepositories();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _getRepositories();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Widget body;
+
+    if (repoBeingFetched == true) {
+      // Show circular progress indicator while
+      // repositories are being fetched
+      body = const Center(
+        child: CircularProgressIndicator(
+          color: Colors.blue,
+        ),
+      );      
+    } else if (GithubApi.currentUser == null) {
+      body = const Center(
+        child: Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Card(
+            child: Padding(
+              padding: EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+              child: Text("Please first provide github api token and username!"),
+            ),
+          ),
+        ),
+      );
+    } else if (repositories == null) {
+      body = Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Padding(
+              padding: EdgeInsets.all(16.0),
+              child: Card(
+                child: Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                  child: Text(
+                    'No repositories could be found!',
+                    style: TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.bold
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 40),
+            StyledTextButton(
+              onPressed: () {
+                setState(() {
+                  repositories = null;
+                });
+                _getRepositories();
+              },
+              text: Text(
+                'Try Again'
+              ),
+            ),
+          ],
+        )
+      );
+    } else {
+      body = SingleChildScrollView(
+        child: Column(
+          children: [
+            const Align(
+              alignment: Alignment.centerLeft,
+              child: Padding(
+                padding: EdgeInsets.only(left: 10.0),
+                child: Text(
+                  'All Repositories',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ),
+            if (repositories!.isEmpty) ... [
+              const Padding(
+                padding: EdgeInsets.all(16.0),
+                child: Card(
+                  child: Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                    child: Text(
+                      "That's it! You've seen all!",
+                      style: TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.bold
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ] else ...[
+              for (int i = 0; i < repositories!.length; i++) ...[
+                ListTile(
+                  leading: const Icon(Icons.folder_special, color: Colors.blueAccent),
+                  title: Text(
+                    repositories![i].fullName,
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  subtitle: Text('${repositories![i].isPrivate? "Private" : "Public"} Repository'),
+                ),
+                if (i != repositories!.length-1) ...[
+                  const Divider(thickness: 1)
+                ]
+              ],
+            ],
+            const SizedBox(height: 10),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                if (currentPage != 1) ...[
+                  IconButton(
+                    onPressed: previousPage,
+                    icon: const Icon(Icons.chevron_left, size: 28),
+                  ),
+                ],
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Text(
+                    "Page $currentPage",
+                    style: const TextStyle( 
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                if (repositories!.length == repoPerPage) ...[
+                  IconButton(
+                    onPressed: nextPage,
+                    icon: Icon(Icons.chevron_right, size: 28),
+                  ),
+                ],
+              ],
+            ),
+          ],
+        ),
+      );
+    }
+    return body;
+  }
+}

--- a/lib/utils/app_notifier.dart
+++ b/lib/utils/app_notifier.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:github_var_updater/main.dart';
 
 
-/// NotificationManager handles user notifications inside the app UI.
+/// AppNotifier helps to show notifications withing app UI.
 /// It supports both, dialog notifications and overlay notifications.
 /// 
 /// Dialog Notifications can be used to notify user about any important event or thing.

--- a/lib/utils/app_notifier.dart
+++ b/lib/utils/app_notifier.dart
@@ -22,6 +22,7 @@ class AppNotifier {
       required BuildContext context,
       required String title,
       required String msg,
+      TextStyle? msgStyle,
       Icon? icon,
       void Function()? okButtonBehaviour}) {
     return AlertDialog(
@@ -58,7 +59,7 @@ class AppNotifier {
           padding: const EdgeInsets.all(8.0),
           child: Text(
             msg,
-            style: const TextStyle(
+            style: msgStyle ?? const TextStyle(
               fontSize: 16,
               color: Colors.black87,
               height: 1.5,
@@ -87,8 +88,11 @@ class AppNotifier {
     );
   }
 
-  static Future<void> showErrorDialog({required String errorMessage,
-      void Function()? okButtonBehaviour}) async {
+  static Future<void> showErrorDialog({
+    required String errorMessage,
+    TextStyle? msgStyle,
+    void Function()? okButtonBehaviour
+  }) async {
     BuildContext? context = homePageKey.currentContext;
     if (context != null) {
       await showDialog(
@@ -100,14 +104,18 @@ class AppNotifier {
               context: context,
               title: 'Error',
               msg: errorMessage,
+              msgStyle: msgStyle,
               icon: Icon(Icons.error_outline, color: Colors.red, size: 24));
         },
       );
     }
   }
 
-  static Future<void> showInfoDialog({required String info,
-      void Function()? okButtonBehaviour}) async {
+  static Future<void> showInfoDialog({
+    required String info,
+    TextStyle? msgStyle,
+    void Function()? okButtonBehaviour
+  }) async {
     BuildContext? context = homePageKey.currentContext;
     if (context != null) {
       await showDialog(
@@ -118,6 +126,7 @@ class AppNotifier {
                 context: context,
                 title: 'Info',
                 msg: info,
+                msgStyle: msgStyle,
                 icon: Icon(Icons.info_outline, color: Colors.blue, size: 24));
           });
     }
@@ -255,44 +264,46 @@ class NotificationWidget extends StatelessWidget {
     required this.message,
     required this.themeColor,
     required this.icon,
-    this.messageStyle = const TextStyle(color: Colors.black, fontSize: 18),
+    this.messageStyle = const TextStyle(fontWeight: FontWeight.bold, fontSize: 14),
     this.onDismissed
   });
 
   @override
   Widget build(BuildContext context) {
-    return Dismissible(
-      key: UniqueKey(),
-      direction: DismissDirection.horizontal,
-      onDismissed: (dir) {
-        // Call on dismissed callback
-        if (onDismissed != null) {
-          onDismissed!(dir);
-        }
+    return Material(
+      child: Dismissible(
+        key: UniqueKey(),
+        direction: DismissDirection.horizontal,
+        onDismissed: (dir) {
+          // Call on dismissed callback
+          if (onDismissed != null) {
+            onDismissed!(dir);
+          }
 
-        // Remove notification from notifications list
-        AppNotifier._removeNotification(this);
-      },
-      child: Container(
-        padding: const EdgeInsets.all(16),
-        decoration: BoxDecoration(
-          color: themeColor.shade50, // Light Shade of themeColor
-          border: Border.all(color: themeColor, width: 2),
-          borderRadius: BorderRadius.circular(12),
-        ),
-        child: Row(
-          children: [
-            icon,
-            const SizedBox(width: 10),
-            Expanded(
-              child: Text(
-                message,
-                style: messageStyle
+          // Remove notification from notifications list
+          AppNotifier._removeNotification(this);
+        },
+        child: Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: themeColor.shade50, // Light Shade of themeColor
+            border: Border.all(color: themeColor, width: 2),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Row(
+            children: [
+              icon,
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  message,
+                  style: messageStyle
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
-      ),
+      )
     );
   }
 }

--- a/lib/utils/app_notifier.dart
+++ b/lib/utils/app_notifier.dart
@@ -1,0 +1,298 @@
+import 'package:flutter/material.dart';
+import 'package:github_var_updater/main.dart';
+
+
+/// NotificationManager handles user notifications inside the app UI.
+/// It supports both, dialog notifications and overlay notifications.
+/// 
+/// Dialog Notifications can be used to notify user about any important event or thing.
+/// Overlay Notifications can be used to notify user about any unimportant event or thing.
+class AppNotifier {
+  static final GlobalKey<HomePageState> _globalKey = GlobalKey<HomePageState>();
+  static final List<NotificationWidget> _notifications = [];
+
+  static GlobalKey<HomePageState> get homePageKey => _globalKey;
+  static List<NotificationWidget> get notifications => _notifications;
+
+  static OverlayEntry? _mainOverlayEntry ;
+
+  /// Returns a styled alert dialog with custom theme, title, icon and message
+  static AlertDialog _getStyledDialog(
+      {required MaterialColor themeColor,
+      required BuildContext context,
+      required String title,
+      required String msg,
+      Icon? icon,
+      void Function()? okButtonBehaviour}) {
+    return AlertDialog(
+      backgroundColor: themeColor.shade50,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(20),
+        side: BorderSide(
+          color: themeColor,
+          width: 2.0,
+        ),
+      ),
+      title: Column(
+        children: [
+          Row(children: [
+            if (icon != null) ...[icon, SizedBox(width: 12)],
+            Text(
+              title,
+              style: TextStyle(
+                fontWeight: FontWeight.bold,
+                fontSize: 20,
+                color: themeColor,
+              ),
+            ),
+          ]),
+          const SizedBox(height: 8),
+          Divider(
+            color: themeColor,
+            thickness: 1.5,
+          )
+        ],
+      ),
+      content: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Text(
+            msg,
+            style: const TextStyle(
+              fontSize: 16,
+              color: Colors.black87,
+              height: 1.5,
+            ),
+          ),
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () {
+            Navigator.pop(context);
+            if (okButtonBehaviour != null) {
+              okButtonBehaviour();
+            }
+          },
+          style: TextButton.styleFrom(
+            backgroundColor: themeColor,
+            foregroundColor: Colors.white,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+            ),
+          ),
+          child: const Text('OK'),
+        ),
+      ],
+    );
+  }
+
+  static Future<void> showErrorDialog({required String errorMessage,
+      void Function()? okButtonBehaviour}) async {
+    BuildContext? context = homePageKey.currentContext;
+    if (context != null) {
+      await showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) {
+          return _getStyledDialog(
+              themeColor: Colors.red,
+              context: context,
+              title: 'Error',
+              msg: errorMessage,
+              icon: Icon(Icons.error_outline, color: Colors.red, size: 24));
+        },
+      );
+    }
+  }
+
+  static Future<void> showInfoDialog({required String info,
+      void Function()? okButtonBehaviour}) async {
+    BuildContext? context = homePageKey.currentContext;
+    if (context != null) {
+      await showDialog(
+          context: context,
+          builder: (context) {
+            return _getStyledDialog(
+                themeColor: Colors.blue,
+                context: context,
+                title: 'Info',
+                msg: info,
+                icon: Icon(Icons.info_outline, color: Colors.blue, size: 24));
+          });
+    }
+  }
+
+  /// It removes given [notification] from [_notifications] list if it is present
+  static void _removeNotification(NotificationWidget notification) {
+    int index = _notifications.indexOf(notification);
+    if (index == -1) return;
+    _notifications.removeAt(index);
+
+    _mainOverlayEntry?.markNeedsBuild();
+
+    if (_notifications.isEmpty) {
+      _mainOverlayEntry?.remove();
+      _mainOverlayEntry?.dispose();
+      _mainOverlayEntry = null;
+    }
+  }
+
+  /// Shows given [notification] on the top portion of screen.
+  /// If not dismissed manually in given [duration], it removes it automatically
+  static void showNotification({
+    required NotificationWidget notification,
+    Duration duration = const Duration(seconds: 5),
+  }) {
+    
+    BuildContext? context = homePageKey.currentContext;
+    if (context == null) return;
+
+    // Get the overlay instance
+    final overlay = Overlay.of(context);
+
+    _notifications.insert(0, notification);
+
+    // Schedules automatic dismissal of notification after given
+    // period of time
+    Future.delayed(duration, () {
+      if (notification.onDismissed != null) {
+        notification.onDismissed!(DismissDirection.none);
+      }
+      _removeNotification(notification);
+    });
+
+    if (_mainOverlayEntry != null) {
+      _mainOverlayEntry!.markNeedsBuild();
+    } else {
+      _mainOverlayEntry = OverlayEntry(
+        builder: (context) {
+          return Positioned(
+            top: MediaQuery.of(context).size.height * 0.1,
+            left: MediaQuery.of(context).size.width * 0.03,
+            right: MediaQuery.of(context).size.width * 0.03,
+            child: ConstrainedBox(
+              constraints: BoxConstraints(
+                maxHeight: MediaQuery.of(context).size.height * 0.25, // 25% of available height
+              ),
+              child: SingleChildScrollView(
+                child: Column(
+                  children: _notifications.map((message) {
+                    return Padding(
+                      padding: EdgeInsets.only(bottom: 8.0),
+                      child: message
+                    );
+                  }).toList()
+                ),
+              ),
+            ),
+          );
+        }
+      );
+      overlay.insert(_mainOverlayEntry!);
+    }
+  }
+
+  static void notifyUserAboutError({
+    required String errorMessage,
+    Duration duration = const Duration(seconds: 5),
+    void Function(DismissDirection)? onDismissed
+  }) {
+    showNotification(
+      notification: NotificationWidget(
+        message: errorMessage,
+        themeColor: Colors.red,
+        icon: Icon(Icons.error_outline, color: Colors.red, size: 24),
+        onDismissed: onDismissed,
+      ),
+      duration: duration
+    );
+  }
+
+  static void notifyUserAboutInfo({
+    required String info,
+    Duration duration = const Duration(seconds: 5),
+    void Function(DismissDirection)? onDismissed
+  }) {
+    showNotification(
+      notification: NotificationWidget(
+        message: info,
+        themeColor: Colors.blue,
+        icon: const Icon(Icons.info_outline, color: Colors.blue, size: 24),
+        onDismissed: onDismissed,
+      ),
+      duration: duration
+    );
+  }
+
+  static void notifyUserAboutSuccess({
+    required String successMessage,
+    Duration duration = const Duration(seconds: 5),
+    void Function(DismissDirection)? onDismissed
+  }) {
+    showNotification(
+      notification: NotificationWidget(
+        message: successMessage,
+        themeColor: Colors.green,
+        icon: const Icon(Icons.check_circle_outline, color: Colors.green, size: 24)
+      ),
+      duration: duration
+    );
+  }
+}
+
+/// It encapsulates fields related to notification message that will appear
+/// on the screen without dialog (like notifications)
+class NotificationWidget extends StatelessWidget {
+  final String message; // The message that is being displayed in the notification
+  final void Function(DismissDirection)? onDismissed;  // What to do when Notifcation is dismissed
+  final MaterialColor themeColor;
+  final Icon icon;
+  final TextStyle messageStyle;
+
+  const NotificationWidget({
+    super.key,
+    required this.message,
+    required this.themeColor,
+    required this.icon,
+    this.messageStyle = const TextStyle(color: Colors.black, fontSize: 18),
+    this.onDismissed
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Dismissible(
+      key: UniqueKey(),
+      direction: DismissDirection.horizontal,
+      onDismissed: (dir) {
+        // Call on dismissed callback
+        if (onDismissed != null) {
+          onDismissed!(dir);
+        }
+
+        // Remove notification from notifications list
+        AppNotifier._removeNotification(this);
+      },
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: themeColor.shade50, // Light Shade of themeColor
+          border: Border.all(color: themeColor, width: 2),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Row(
+          children: [
+            icon,
+            const SizedBox(width: 10),
+            Expanded(
+              child: Text(
+                message,
+                style: messageStyle
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/utils/keystore.dart
+++ b/lib/utils/keystore.dart
@@ -1,10 +1,12 @@
+import 'package:github_var_updater/utils/app_notifier.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-// This class helps to store key-value pairs that persists
-// even after app is closed. They are stored locally.
+/// This class helps to store key-value pairs that persists
+/// even after app is closed. They are stored locally and will
+/// be cleared if app's data is cleared.
 class Keystore {
 
-  // Stores the given key value pair
+  /// Stores the given key value pair. Doesn't throws exception
   static Future<void> savePair({required String key, required dynamic value}) async {
     try {
       SharedPreferences preference = await SharedPreferences.getInstance();
@@ -24,23 +26,33 @@ class Keystore {
         throw UnsupportedError('The type "${value.runtimeType}" isn\'t supported!');
       }
     } catch (e) {
-      print('Exception occured: ${e.toString()}');
+      AppNotifier.showErrorDialog(errorMessage: e.toString());
     }
   }
 
-  // Retrives the value associated with given key. Returns null if can't find.
+  /// Retrives the value associated with given key. Returns null if can't find.
+  /// 
+  /// Doesn't throw exception
   static Future<dynamic> getValueForKey({required String key}) async {
     try {
       SharedPreferences pref = await SharedPreferences.getInstance();
       return pref.get(key);
     } catch (e) {
-      print('Exception occured: ${e.toString()}');
+      AppNotifier.showErrorDialog(errorMessage: e.toString());
     }
     return null;
   }
 
-  // Tells whether given key is present in the keystore
+  /// Tells whether given key is present in the keystore
+  /// 
+  /// Doesn't throw exception
   static Future<bool> contains({required String key}) async {
-    return (await SharedPreferences.getInstance()).containsKey(key);
+    try {
+      SharedPreferences pref = await SharedPreferences.getInstance();
+      return pref.containsKey(key);
+    } catch (e) {
+      AppNotifier.showErrorDialog(errorMessage: e.toString());
+    }
+    return false;
   }
 }

--- a/lib/widgets/input_widget.dart
+++ b/lib/widgets/input_widget.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+class InputWidget extends StatelessWidget {
+
+  final TextEditingController? controller;
+  final String? labelText;
+  final String? hintText;
+  final String? initialValue;
+  final bool readOnly;
+  final String prefixText;
+
+  const InputWidget({
+    super.key,
+    this.controller,
+    this.labelText,
+    this.hintText,
+    this.initialValue,
+    this.prefixText = "",
+    this.readOnly = false
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: 8.0),
+      child: Row(
+        children: [
+          Text(
+            prefixText,
+            style: const TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.bold
+            ),
+          ),
+          const SizedBox(width: 20),
+          Expanded(
+            child: TextFormField(
+              controller: controller,
+              readOnly: readOnly,
+              initialValue: initialValue,
+              decoration: InputDecoration(
+                labelText:  labelText,
+                hintText: hintText,
+                border: OutlineInputBorder(),
+              ),
+            ),
+          ),
+        ]
+      ),
+    );
+  }
+}

--- a/lib/widgets/styled_text_button.dart
+++ b/lib/widgets/styled_text_button.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class StyledTextButton extends StatelessWidget {
+  final void Function() onPressed;
+  final Text text;
+
+  const StyledTextButton({
+    super.key,
+    required this.onPressed,
+    required this.text,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: onPressed,
+      style: ElevatedButton.styleFrom(
+        backgroundColor: Color(0xFF3B71CA),
+        foregroundColor: Color(0xFFD6D6D6),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+        child: text,
+      ),
+    );
+  }
+}

--- a/recovered/lib/api_service/github_api.dart
+++ b/recovered/lib/api_service/github_api.dart
@@ -1,0 +1,133 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:github_var_updater/utils/app_notifier.dart';
+import 'package:http/http.dart' as http;
+import 'package:github_var_updater/utils/keystore.dart';
+
+/// Encapsulates required fields about github user
+class GithubUser {
+  final String username;
+  final String accessToken;
+
+  const GithubUser({required this.username, required this.accessToken});
+}
+
+enum RepositoryRelationType {
+  userOwned,        /// Owned by the user (Highest Priority)
+  collaboratorOnly, /// User is a collaborator (but not in an org)
+  organizationOwned /// Organization-Owned Repositories (Lowest Priority)
+}
+
+/// Encapsulates required fields about github repository
+class GithubRepository {
+  final String name;
+  final String fullName;
+  final bool isPrivate;
+  final RepositoryRelationType relationType;
+
+  const GithubRepository({
+    required this.name,
+    required this.fullName,
+    required this.isPrivate,
+    required this.relationType,
+  });
+}
+
+/// This class is used to get user data from github using api requests
+class GithubApi {
+  static final String _baseUrl = 'https://api.github.com';
+  static GithubUser? _user;
+
+  static GithubUser? get currentUser => _user;
+
+  /// Sets given [user] the current user and any 
+  static void setCurrentUser(GithubUser user) {
+    _user = user;
+    Keystore.savePair(key: 'github_username', value: user.username);
+    Keystore.savePair(key: 'github_access_token', value: user.accessToken);
+  }
+
+  static Future<void> loadPreviousUser() async {
+    if (await Keystore.contains(key: 'github_username') && await Keystore.contains(key: 'github_access_token')) {
+      _user = GithubUser(
+        username: await Keystore.getValueForKey(key: 'github_username') as String,
+        accessToken: await Keystore.getValueForKey(key: 'github_access_token') as String
+      );
+    }
+  }
+
+  /// Returns user repositories
+  static Future<List<GithubRepository>> getUserRepos({
+    int requiredPage = 1,
+    int perPage = 30
+  }) async {
+    if (_user == null) {
+      AppNotifier.showErrorDialog(
+        errorMessage: "Cannot get repositories for current user! Please provide required information on github account section!"
+      );
+      return [];  // Return empty list
+    }
+
+    late final http.Response response;
+
+    try {
+      final uri = Uri.parse('$_baseUrl/user/repos?per_page=$perPage&page=$requiredPage');
+      response = await http.get(
+        uri,
+        headers: {
+          'Authorization' : 'Bearer ${_user?.accessToken}',
+          'Accept' : 'application/vnd.github+json'
+        }
+      );
+    } on SocketException {
+      AppNotifier.notifyUserAboutInfo(info: 'Please check your internet!');
+      return [];
+    } catch (e) {
+      AppNotifier.showErrorDialog(errorMessage: 'Unexpected error occured: ${e.toString()}');
+      return [];
+    }
+
+    if (response.statusCode == 200) {
+      List<dynamic> repos = jsonDecode(response.body);
+
+      List<GithubRepository> repositories = repos.map((repoAsJson) {
+        RepositoryRelationType relationType;
+        String ownerLogin = repoAsJson['owner']['login'];
+        String ownerType = repoAsJson['owner']['type'];
+
+        if (ownerLogin == _user!.username) {
+          relationType = RepositoryRelationType.userOwned;
+        } else if (ownerType == 'Organization') {
+          relationType = RepositoryRelationType.organizationOwned;
+        } else {
+          relationType = RepositoryRelationType.collaboratorOnly;
+        }
+
+        return GithubRepository(
+          name: repoAsJson['name'],
+          fullName: repoAsJson['full_name'],
+          isPrivate: repoAsJson['private'],
+          relationType: relationType,
+        );
+      }).toList();
+
+      repositories.sort((a, b) {
+        return a.relationType.index.compareTo(b.relationType.index);
+      });
+  
+      return repositories;
+    } else if (response.statusCode == 401) {
+      AppNotifier.notifyUserAboutError(errorMessage: 'Please provide valid credentials! Current ones are invalid!');
+    } else if (response.statusCode == 403) {
+      AppNotifier.notifyUserAboutError(
+        errorMessage: "Either github api rate limit exceeded or your token doesn't have required permissions"
+      );
+    } else {
+      AppNotifier.showErrorDialog(
+        errorMessage: 'Unknown error occured while trying to get repositories.\nResponse Status Code: ${response.statusCode}'
+      );
+    }
+
+    return [];
+  }
+}

--- a/recovered/lib/main.dart
+++ b/recovered/lib/main.dart
@@ -17,7 +17,7 @@ class MyApp extends StatelessWidget {
       title: 'Github Var Updater',
       theme: ThemeData.light(),
       darkTheme: ThemeData.dark(),
-      themeMode: ThemeMode.dark,  // Follow system settings
+      themeMode: ThemeMode.system,  // Follow system settings
       home: MainScreen(key: AppNotifier.homePageKey),
     );
   }

--- a/recovered/lib/screens/main_screen.dart
+++ b/recovered/lib/screens/main_screen.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import 'package:github_var_updater/sections/github_account_section.dart';
+import 'package:github_var_updater/sections/repository_section.dart';
+
+class MainScreen extends StatefulWidget {
+  const MainScreen({super.key});
+
+  @override
+  State<MainScreen> createState() => MainScreenState();
+}
+
+class MainScreenState extends State<MainScreen> {
+
+  late PageController _pageController;
+  int _selectedIndex = 0;
+
+  void _onPageChanged(int index) {
+    setState(() => _selectedIndex = index);
+  }
+
+  void _onItemTapped(int index) {
+    _pageController.animateToPage(
+      index, 
+      duration: Duration(milliseconds: 500),
+      curve: Curves.ease
+    );  
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _pageController = PageController();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        centerTitle: true,
+        title: const Text(
+          'Github Var Updater',
+          style: TextStyle(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.vertical(
+            bottom: Radius.circular(8.0),
+          ),
+        ),
+      ),
+      body: PageView(
+        controller: _pageController,
+        onPageChanged: _onPageChanged,
+        children: [
+          const GithubAccountSection(),
+          const RepositorySection(),
+        ],
+      ),
+      bottomNavigationBar: Container(
+        decoration: BoxDecoration(
+          borderRadius: const BorderRadius.only(
+            topLeft: Radius.circular(20),
+            topRight: Radius.circular(20),
+          ),
+          boxShadow: [
+            BoxShadow(color: Theme.of(context).primaryColorDark, spreadRadius: 0, blurRadius: 10),
+          ]
+        ),
+        child: ClipRRect(
+          borderRadius: const BorderRadius.only(
+            topLeft: Radius.circular(20),
+            topRight: Radius.circular(20),
+          ),
+          child: BottomNavigationBar(
+            items: [
+              const BottomNavigationBarItem(
+                icon: Icon(Icons.person, size: 24),
+                label: 'Github Account',
+                activeIcon: Icon(Icons.person, size: 28)
+              ),
+              const BottomNavigationBarItem(
+                icon: Icon(Icons.list_alt, size: 24),
+                label: 'Repositories',
+                activeIcon: Icon(Icons.list_alt, size: 28)
+              )
+            ],
+            backgroundColor: Theme.of(context).dialogBackgroundColor,
+            currentIndex: _selectedIndex,
+            selectedItemColor: Colors.blue,
+            onTap: _onItemTapped,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/recovered/lib/sections/github_account_section.dart
+++ b/recovered/lib/sections/github_account_section.dart
@@ -1,0 +1,255 @@
+import 'package:flutter/material.dart';
+import 'package:github_var_updater/api_service/github_api.dart';
+import 'package:github_var_updater/utils/app_notifier.dart';
+import 'package:github_var_updater/widgets/input_widget.dart';
+import 'package:github_var_updater/widgets/styled_text_button.dart';
+
+class GithubAccountSection extends StatefulWidget {
+  const GithubAccountSection({super.key});
+
+  @override
+  State<GithubAccountSection> createState() => _GithubAccountSectionState();
+}
+
+class _GithubAccountSectionState extends State<GithubAccountSection> {
+  final TextEditingController usernameController = TextEditingController();
+  final TextEditingController tokenController = TextEditingController();
+
+  bool areCredentialsRequired = true;
+
+  void _setCurrentUser() {
+    if (usernameController.text.isEmpty || tokenController.text.isEmpty) {
+      AppNotifier.notifyUserAboutError(errorMessage: 'Both fields are required! Please provide your username and github api token.');
+      return;
+    }
+
+    GithubApi.setCurrentUser(
+      GithubUser(
+        username: usernameController.text,
+        accessToken: tokenController.text,
+      )
+    );
+
+    // This will cause a rebuild
+    _toggleCredentialsRequired();
+  }
+
+  void _toggleCredentialsRequired() {
+    setState(() => areCredentialsRequired = !areCredentialsRequired);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    areCredentialsRequired = GithubApi.currentUser == null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.all(8.0),
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (areCredentialsRequired) ...[
+              InputWidget(
+                controller: usernameController,
+                prefixText: 'Username',
+                labelText: 'Github Username',
+                hintText: 'Enter your github username',
+              ),
+              const SizedBox(height: 40),
+              InputWidget(
+                controller: tokenController,
+                prefixText: 'Api Token',
+                labelText: 'Github Api Token',
+                hintText: 'Paste your github api token here',
+              ),
+              const SizedBox(height: 40),
+              StyledTextButton(
+                onPressed: _setCurrentUser,
+                text: const Text(
+                  'Continue',
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ] else ...[
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const Text(
+                        'Current User Details',
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 25
+                        ),
+                      ),
+                      const Divider(
+                        thickness: 1,
+                      ),
+                      const SizedBox(height: 30),
+                      InputWidget(
+                        initialValue: GithubApi.currentUser?.username ?? 'Unexpectedly Null',
+                        prefixText: 'Username',
+                        readOnly: true,
+                      ),
+                      const SizedBox(height: 30),
+                      InputWidget(
+                        initialValue: GithubApi.currentUser?.accessToken ?? 'Unexpectedly Null',
+                        prefixText: 'Api Token',
+                        readOnly: true,
+                      ),
+                      const SizedBox(height: 30),
+                      StyledTextButton(
+                        onPressed: _toggleCredentialsRequired,
+                        text: const Text(
+                          'Change User',
+                          style: TextStyle(
+                            fontSize: 14,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              
+
+              /*Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Row (
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text(
+                            'Your Github Token',
+                            style: TextStyle(
+                              fontWeight: FontWeight.bold,
+                              fontSize: 25,
+                            ),
+                          ),
+                          IconButton(
+                            icon: Icon(Icons.copy),
+                            tooltip: 'Copy Token',
+                            onPressed: () =>
+                              Clipboard.setData(ClipboardData(text: GithubApi.currentUser?.accessToken ?? '')),
+                          ),
+                        ],
+                      ),
+                      const Divider(),
+                      Text(
+                        "${GithubApi.currentUser?.accessToken}",
+                        style: TextStyle(
+                          fontSize: 18,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),*/
+            ]
+          ],
+        ),
+      ),
+    );
+
+    /*return Padding(
+      padding: EdgeInsets.all(8.0),
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            if (token == null) ...[
+              TextField(
+                controller: controller,
+                decoration: InputDecoration(
+                  icon: Icon(Icons.person),
+                  labelText: 'Github Access Token',
+                  hintText: 'Paste github access token here',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: _saveApiToken,
+                child: Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 24, vertical: 14),
+                  child: Text('Continue'),
+                ),
+              ),
+            ] else ...[
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Row (
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          Text(
+                            'Your Github Token',
+                            style: TextStyle(
+                              fontWeight: FontWeight.bold,
+                              fontSize: 25,
+                            ),
+                          ),
+                          IconButton(
+                            icon: Icon(Icons.copy),
+                            tooltip: 'Copy Token',
+                            onPressed: () =>
+                              Clipboard.setData(ClipboardData(text: token ?? '')),
+                          ),
+                        ],
+                      ),
+                      const Divider(),
+                      Text(
+                        '$token',
+                        style: TextStyle(
+                          fontSize: 18,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton.icon(
+                onPressed: () => setState(() => token = null),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: Colors.red,
+                  foregroundColor: Colors.white,
+                  iconColor: Colors.white,
+                  iconSize: 35,
+                ),
+                icon: Icon(Icons.change_circle),
+                label: Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 24, vertical: 14),
+                  child: Text(
+                    'Change Token',
+                    style: TextStyle(
+                      backgroundColor: Colors.red,
+                      color: Colors.white,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );*/
+  }
+}

--- a/recovered/lib/sections/repository_section.dart
+++ b/recovered/lib/sections/repository_section.dart
@@ -1,0 +1,195 @@
+import 'package:flutter/material.dart';
+import 'package:github_var_updater/api_service/github_api.dart';
+import 'package:github_var_updater/widgets/styled_text_button.dart';
+
+class RepositorySection extends StatefulWidget {
+  const RepositorySection({super.key});
+
+  @override
+  State<RepositorySection> createState() => _RepositorySectionState();
+}
+
+class _RepositorySectionState extends State<RepositorySection> {
+
+  List<GithubRepository>? repositories;
+  int currentPage=1;
+  static const repoPerPage = 7;
+
+  Future<void> _getRepositories() async {
+    repositories = await GithubApi.getUserRepos(
+      requiredPage: currentPage,
+      perPage: repoPerPage,
+    );
+    setState(() {/* Repositories are fetched */});
+  }
+
+  void nextPage() {
+    setState(() {
+      currentPage++;
+      // So that progress indicator can be shown
+      repositories = null;
+    });
+    // Set state will be called in this repo
+    _getRepositories();
+  }
+
+  void previousPage() {
+    setState(() {
+      currentPage--;
+      // So that progress indicator can be shown
+      repositories = null;
+    });
+    _getRepositories();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _getRepositories();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Widget body;
+
+    if (GithubApi.currentUser == null) {
+      body = const Center(
+        child: Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Card(
+            child: Padding(
+              padding: EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+              child: Text("Please first provide github api token and username!"),
+            ),
+          ),
+        ),
+      );
+    } else if (repositories == null) {
+      // Show circular progress indicator while
+      // repositories are being fetched
+      body = const Center(
+        child: CircularProgressIndicator(
+          color: Colors.blue,
+        ),
+      );
+    } else if (repositories!.isEmpty) {
+      body = Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Padding(
+              padding: EdgeInsets.all(16.0),
+              child: Card(
+                child: Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                  child: Text(
+                    'No repositories could be found!',
+                    style: TextStyle(
+                      fontSize: 15,
+                      fontWeight: FontWeight.bold
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(height: 40),
+            StyledTextButton(
+              onPressed: () {
+                setState(() {
+                  repositories = null;
+                });
+                _getRepositories();
+              },
+              text: Text(
+                'Try Again'
+              ),
+            ),
+          ],
+        )
+      );
+    } else {
+      body = SingleChildScrollView(
+        child: Column(
+          children: [
+            const Align(
+              alignment: Alignment.centerLeft,
+              child: Padding(
+                padding: EdgeInsets.only(left: 10.0),
+                child: Text(
+                  'All Repositories',
+                  style: TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ),
+            if (repositories!.isEmpty) ... [
+              const Padding(
+                padding: EdgeInsets.all(16.0),
+                child: Card(
+                  child: Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+                    child: Text(
+                      'No repositories could be fetched!',
+                      style: TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.bold
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ] else ...[
+              for (int i = 0; i < repositories!.length; i++) ...[
+                ListTile(
+                  leading: const Icon(Icons.folder_special, color: Colors.blueAccent),
+                  title: Text(
+                    repositories![i].fullName,
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  subtitle: Text('${repositories![i].isPrivate? "Private" : "Public"} Repository'),
+                ),
+                if (i != repositories!.length-1) ...[
+                  const Divider(thickness: 1)
+                ]
+              ],
+            ],
+            const SizedBox(height: 10),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                if (currentPage != 1) ...[
+                  IconButton(
+                    onPressed: previousPage,
+                    icon: const Icon(Icons.chevron_left, size: 28),
+                  ),
+                ],
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16),
+                  child: Text(
+                    "Page $currentPage",
+                    style: const TextStyle( 
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                if (repositories!.length == repoPerPage) ...[
+                  IconButton(
+                    onPressed: nextPage,
+                    icon: Icon(Icons.chevron_right, size: 28),
+                  ),
+                ],
+              ],
+            ),
+          ],
+        ),
+      );
+    }
+
+    return body;
+  }
+}

--- a/recovered/lib/utils/app_notifier.dart
+++ b/recovered/lib/utils/app_notifier.dart
@@ -22,7 +22,6 @@ class AppNotifier {
       required BuildContext context,
       required String title,
       required String msg,
-      TextStyle? msgStyle,
       Icon? icon,
       void Function()? okButtonBehaviour}) {
     return AlertDialog(
@@ -59,7 +58,7 @@ class AppNotifier {
           padding: const EdgeInsets.all(8.0),
           child: Text(
             msg,
-            style: msgStyle ?? const TextStyle(
+            style: const TextStyle(
               fontSize: 16,
               color: Colors.black87,
               height: 1.5,
@@ -88,11 +87,8 @@ class AppNotifier {
     );
   }
 
-  static Future<void> showErrorDialog({
-    required String errorMessage,
-    TextStyle? msgStyle,
-    void Function()? okButtonBehaviour
-  }) async {
+  static Future<void> showErrorDialog({required String errorMessage,
+      void Function()? okButtonBehaviour}) async {
     BuildContext? context = homePageKey.currentContext;
     if (context != null) {
       await showDialog(
@@ -104,18 +100,14 @@ class AppNotifier {
               context: context,
               title: 'Error',
               msg: errorMessage,
-              msgStyle: msgStyle,
               icon: Icon(Icons.error_outline, color: Colors.red, size: 24));
         },
       );
     }
   }
 
-  static Future<void> showInfoDialog({
-    required String info,
-    TextStyle? msgStyle,
-    void Function()? okButtonBehaviour
-  }) async {
+  static Future<void> showInfoDialog({required String info,
+      void Function()? okButtonBehaviour}) async {
     BuildContext? context = homePageKey.currentContext;
     if (context != null) {
       await showDialog(
@@ -126,7 +118,6 @@ class AppNotifier {
                 context: context,
                 title: 'Info',
                 msg: info,
-                msgStyle: msgStyle,
                 icon: Icon(Icons.info_outline, color: Colors.blue, size: 24));
           });
     }
@@ -264,46 +255,44 @@ class NotificationWidget extends StatelessWidget {
     required this.message,
     required this.themeColor,
     required this.icon,
-    this.messageStyle = const TextStyle(fontWeight: FontWeight.bold, fontSize: 14, color: Colors.black87),
+    this.messageStyle = const TextStyle(color: Colors.black, fontSize: 18),
     this.onDismissed
   });
 
   @override
   Widget build(BuildContext context) {
-    return Material(
-      child: Dismissible(
-        key: UniqueKey(),
-        direction: DismissDirection.horizontal,
-        onDismissed: (dir) {
-          // Call on dismissed callback
-          if (onDismissed != null) {
-            onDismissed!(dir);
-          }
+    return Dismissible(
+      key: UniqueKey(),
+      direction: DismissDirection.horizontal,
+      onDismissed: (dir) {
+        // Call on dismissed callback
+        if (onDismissed != null) {
+          onDismissed!(dir);
+        }
 
-          // Remove notification from notifications list
-          AppNotifier._removeNotification(this);
-        },
-        child: Container(
-          padding: const EdgeInsets.all(16),
-          decoration: BoxDecoration(
-            color: themeColor.shade50, // Light Shade of themeColor
-            border: Border.all(color: themeColor, width: 2),
-            borderRadius: BorderRadius.circular(12),
-          ),
-          child: Row(
-            children: [
-              icon,
-              const SizedBox(width: 10),
-              Expanded(
-                child: Text(
-                  message,
-                  style: messageStyle
-                ),
-              ),
-            ],
-          ),
+        // Remove notification from notifications list
+        AppNotifier._removeNotification(this);
+      },
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        decoration: BoxDecoration(
+          color: themeColor.shade50, // Light Shade of themeColor
+          border: Border.all(color: themeColor, width: 2),
+          borderRadius: BorderRadius.circular(12),
         ),
-      )
+        child: Row(
+          children: [
+            icon,
+            const SizedBox(width: 10),
+            Expanded(
+              child: Text(
+                message,
+                style: messageStyle
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/recovered/lib/widgets/input_widget.dart
+++ b/recovered/lib/widgets/input_widget.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+
+class InputWidget extends StatelessWidget {
+
+  final TextEditingController? controller;
+  final String? labelText;
+  final String? hintText;
+  final String? initialValue;
+  final bool readOnly;
+  final String prefixText;
+
+  const InputWidget({
+    super.key,
+    this.controller,
+    this.labelText,
+    this.hintText,
+    this.initialValue,
+    this.prefixText = "",
+    this.readOnly = false
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: EdgeInsets.symmetric(horizontal: 8.0),
+      child: Row(
+        children: [
+          Text(
+            prefixText,
+            style: const TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.bold
+            ),
+          ),
+          const SizedBox(width: 20),
+          Expanded(
+            child: TextFormField(
+              controller: controller,
+              readOnly: readOnly,
+              initialValue: initialValue,
+              decoration: InputDecoration(
+                labelText:  labelText,
+                hintText: hintText,
+                border: OutlineInputBorder(),
+              ),
+            ),
+          ),
+        ]
+      ),
+    );
+  }
+}

--- a/recovered/lib/widgets/styled_text_button.dart
+++ b/recovered/lib/widgets/styled_text_button.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class StyledTextButton extends StatelessWidget {
+  final void Function() onPressed;
+  final Text text;
+
+  const StyledTextButton({
+    super.key,
+    required this.onPressed,
+    required this.text,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: onPressed,
+      style: ElevatedButton.styleFrom(
+        backgroundColor: Color(0xFF3B71CA),
+        foregroundColor: Color(0xFFD6D6D6),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+        child: text,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
**Issue:** #7 

### Changes Summary:

- Divided Project into sub folders for modularity:
  - `lib/`
    - `api_service` : Contains api related classes  (`github_service.dart`).
    - `screens` : Contains full screens i.e, a widget with scaffold. The app has only one so it contains `main_screen.dart`.
    - `sections` : Contains sections of the screen. `github_account_section` and `repository_section.dart` are present here.
    - `utils` : Utility classes and methods are here i.e, `app_notifier.dart` and `keystore.dart`.
    - `widgets` : Any reusable widgets. `input_widget.dart` and `styled_text_button.dart` are here.
    - `main.dart` : The main file.
- Changed theme of the app from Green to `Dark` and `Light` theme which will be selected based on system settings.
- Enhanced UI.
- Created a new page (or section in this context) on which, user can see his repositories.