### PR TITLE
Fix User Info Lost Problem

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:github_var_updater/utils/app_notifier.dart';
 import 'package:github_var_updater/screens/main_screen.dart';
 
 void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
   await GithubApi.loadPreviousUser();
   runApp(const MyApp());
 }


### PR DESCRIPTION
**Issue:** #19 

### Problem Cause:
- The problem was occuring because the flutter's engine wasn't properly initialized when used.
- Specifically this code block:

  ```
  void main() async {
    await GithubApi.loadPreviousUser();
    runApp(const MyApp());
  }
  ```
The problem is that the loadPreviousUser() uses some flutter plugins (MethodChannels by `SharedPreferences`), but the engine wasn't properly initialized and it caused asynchronous suspension, or in other words, suspension of the `GithubApi.loadPreviousUser()` method.

### Problem Solution:
- Added `WidgetsFlutterBinding.ensureInitialized();` before calling `GithubApi.loadPreviousUser()` method, which ensures flutter is properly initialized before use.